### PR TITLE
add WolfGuard and file output support 

### DIFF
--- a/.github/workflows/macsec-integration.yml
+++ b/.github/workflows/macsec-integration.yml
@@ -1,0 +1,78 @@
+name: MACsec Integration Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  macsec-integration:
+    name: MACsec + Arnika + QKD Simulator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout arnika
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y iproute2 curl jq
+
+      - name: Build arnika and QKD simulator
+        run: |
+          go build -o build/arnika .
+          cd tools && go build -o ../build/qkd-simulator mock.go
+
+      - name: Set up network namespaces with MACsec
+        run: |
+          mkdir -p /tmp/macsec-test/node-a /tmp/macsec-test/node-b
+          sudo bash ci/macsec/setup-namespaces.sh
+
+      - name: Start QKD simulator
+        run: |
+          ./build/qkd-simulator &> /tmp/macsec-test/qkd-simulator.log &
+          echo $! > /tmp/macsec-test/qkd-simulator.pid
+          for i in $(seq 1 15); do
+            if curl -s http://192.168.100.1:8080/api/v1/keys/CONSB/enc_keys > /dev/null 2>&1; then
+              echo "QKD simulator is ready"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Start arnika nodes
+        run: |
+          sudo bash ci/macsec/start-nodes.sh
+
+      - name: Verify MACsec SA injection
+        run: |
+          sudo bash ci/macsec/verify.sh
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "====== QKD Simulator Logs ======"
+          cat /tmp/macsec-test/qkd-simulator.log || true
+          echo "====== Node-A Arnika Logs ======"
+          cat /tmp/macsec-test/node-a/arnika.log || true
+          echo "====== Node-B Arnika Logs ======"
+          cat /tmp/macsec-test/node-b/arnika.log || true
+          echo "====== MACsec State (ns-a) ======"
+          sudo ip netns exec ns-a ip macsec show || true
+          echo "====== MACsec State (ns-b) ======"
+          sudo ip netns exec ns-b ip macsec show || true
+
+      - name: Cleanup
+        if: always()
+        run: |
+          sudo ip netns del ns-a 2>/dev/null || true
+          sudo ip netns del ns-b 2>/dev/null || true
+          kill $(cat /tmp/macsec-test/qkd-simulator.pid 2>/dev/null) 2>/dev/null || true
+          sudo rm -rf /tmp/macsec-test

--- a/.github/workflows/wolfguard-integration.yml
+++ b/.github/workflows/wolfguard-integration.yml
@@ -1,0 +1,148 @@
+name: wolfGuard Integration Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  wolfguard-integration:
+    name: wolfGuard + Arnika + QKD Simulator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout arnika
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            autoconf automake libtool \
+            linux-headers-$(uname -r) \
+            iproute2 \
+            build-essential \
+            curl jq
+
+      - name: Clone wolfSSL and wolfGuard side by side
+        run: |
+          git clone --depth 1 https://github.com/wolfssl/wolfssl.git /tmp/wolfssl
+          git clone --depth 1 https://github.com/wolfSSL/wolfGuard.git /tmp/wolfguard
+
+      - name: Build wolfSSL (userspace + kernel module)
+        working-directory: /tmp/wolfssl
+        run: |
+          KERNEL_SRC="/usr/src/linux-headers-$(uname -r)"
+          ./autogen.sh
+          ./configure --quiet \
+            --enable-wolfguard \
+            --enable-cryptonly \
+            --enable-intelasm \
+            --enable-linuxkm \
+            --with-linux-source="$KERNEL_SRC" \
+            --prefix="$(pwd)/linuxkm/build"
+          make -j$(nproc) module
+          sudo make install
+          sudo ldconfig
+          # linuxkm_memory.h is referenced by installed headers but not
+          # copied by make install — place it where wolfGuard Kbuild expects it
+          sudo mkdir -p linuxkm/build/include/linuxkm
+          sudo cp linuxkm/linuxkm_memory.h linuxkm/build/include/linuxkm/
+          # Install kernel module to system module directory
+          sudo mkdir -p "/lib/modules/$(uname -r)/extra"
+          sudo cp linuxkm/libwolfssl.ko "/lib/modules/$(uname -r)/extra/"
+          sudo depmod -a
+          sudo modprobe libwolfssl
+
+      - name: Build wolfGuard (userspace tool + kernel module)
+        working-directory: /tmp/wolfguard
+        run: |
+          KERNEL_SRC="/usr/src/linux-headers-$(uname -r)"
+          # Build wg-fips userspace tool
+          make -C user-src -j$(nproc)
+          sudo make -C user-src install
+          # Build kernel module — Kbuild defaults to ../../wolfssl for WOLFSSL_ROOT
+          make -C kernel-src -j$(nproc) \
+            KERNELDIR="$KERNEL_SRC" \
+            KERNELRELEASE="$(uname -r)"
+          sudo mkdir -p "/lib/modules/$(uname -r)/extra"
+          sudo cp kernel-src/wolfguard.ko "/lib/modules/$(uname -r)/extra/"
+          sudo depmod -a
+
+      - name: Load wolfGuard kernel module
+        run: |
+          # Unload standard wireguard if loaded
+          sudo modprobe -r wireguard 2>/dev/null || true
+          # libwolfssl already loaded during build; load wolfguard
+          sudo modprobe wolfguard
+          # Verify both modules are loaded
+          lsmod | grep wolfguard
+          lsmod | grep libwolfssl
+
+      - name: Generate WireGuard keys (using wg-fips)
+        run: |
+          mkdir -p /tmp/wolfguard-test/node-a /tmp/wolfguard-test/node-b
+          sudo wg-fips genkey | tee /tmp/wolfguard-test/node-a/private.key | sudo wg-fips pubkey > /tmp/wolfguard-test/node-a/public.key
+          sudo wg-fips genkey | tee /tmp/wolfguard-test/node-b/private.key | sudo wg-fips pubkey > /tmp/wolfguard-test/node-b/public.key
+          chmod 600 /tmp/wolfguard-test/node-a/private.key /tmp/wolfguard-test/node-b/private.key
+
+      - name: Build arnika and QKD simulator
+        run: |
+          go build -o build/arnika .
+          cd tools && go build -o ../build/qkd-simulator mock.go
+
+      - name: Set up network namespaces
+        run: |
+          sudo bash ci/wolfguard/setup-namespaces.sh
+
+      - name: Start QKD simulator
+        run: |
+          ./build/qkd-simulator &> /tmp/wolfguard-test/qkd-simulator.log &
+          echo $! > /tmp/wolfguard-test/qkd-simulator.pid
+          # Wait for simulator to be ready
+          for i in $(seq 1 15); do
+            if curl -s http://192.168.100.1:8080/api/v1/keys/CONSB/enc_keys > /dev/null 2>&1; then
+              echo "QKD simulator is ready"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Start arnika nodes
+        run: |
+          sudo bash ci/wolfguard/start-nodes.sh
+
+      - name: Wait for key exchange
+        run: sleep 15
+
+      - name: Verify PSK injection
+        run: |
+          sudo bash ci/wolfguard/verify.sh
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          echo "====== QKD Simulator Logs ======"
+          cat /tmp/wolfguard-test/qkd-simulator.log || true
+          echo "====== Node-A Arnika Logs ======"
+          cat /tmp/wolfguard-test/node-a/arnika.log || true
+          echo "====== Node-B Arnika Logs ======"
+          cat /tmp/wolfguard-test/node-b/arnika.log || true
+          echo "====== WireGuard Status (ns-a) ======"
+          sudo ip netns exec ns-a wg-fips show wg0 || true
+          echo "====== WireGuard Status (ns-b) ======"
+          sudo ip netns exec ns-b wg-fips show wg0 || true
+
+      - name: Cleanup
+        if: always()
+        run: |
+          sudo ip netns del ns-a 2>/dev/null || true
+          sudo ip netns del ns-b 2>/dev/null || true
+          kill $(cat /tmp/wolfguard-test/qkd-simulator.pid 2>/dev/null) 2>/dev/null || true
+          sudo rm -rf /tmp/wolfguard-test

--- a/README.md
+++ b/README.md
@@ -302,12 +302,118 @@ Arnika must be configured via environment variables, following are available:
 | KMS_BACKOFF_BASE_DELAY    | Initial delay before retrying a failed KMS request (exponential backoff applies)                             | 100ms                                    |
 | KMS_RETRY_INTERVAL        | Time interval between retry attempts after a failed KMS key request                                          | 60s                                      |
 | INTERVAL                  | Interval between regular key requests to the KMS; should align with WireGuard rekey interval                 | 120s                                     |
-| WIREGUARD_INTERFACE       | Name of the WireGuard network interface to configure                                                         | qcicat0                                  |
-| WIREGUARD_PEER_PUBLIC_KEY | Public key of the WireGuard peer for secure association                                                      | 8978940b-fb48-4ebf-ad7d-ca36a987fc32     |
+| KEY_HANDLER               | Key output handler: `wireguard` (default), `wolfguard`, `macsec`, or `file`                                  | wireguard                                |
+| WIREGUARD_INTERFACE       | Name of the WireGuard/wolfGuard network interface (required for `wireguard`/`wolfguard` handlers)            | qcicat0                                  |
+| WIREGUARD_PEER_PUBLIC_KEY | Public key of the WireGuard/wolfGuard peer (required for `wireguard`/`wolfguard` handlers)                   | H9adDtDH...nsHc=                         |
+| MACSEC_INTERFACE          | Name of the MACsec network interface (required for `macsec` handler)                                         | macsec0                                  |
+| MACSEC_RX_SCI             | Peer's Secure Channel Identifier, 16 hex characters (required for `macsec` handler)                          | 001122334455ffff                          |
+| KEY_OUTPUT_FILE           | File path to write the PSK to (required for `file` handler)                                                  | /tmp/arnika.psk                          |
 | PQC_PSK_FILE              | File path containing the PQC-generated preshared key (from Rosenpass or similar)                             | /rosenpass/pqc.psk                       |
 | MODE                      | Operation mode: "QkdAndPqcRequired", "AtLeastQkdRequired", "AtLeastPqcRequired", or "EitherQkdOrPqcRequired" | AtLeastQkdRequired                       |
 | ARNIKA_ID                 | Optional identifier (up to 5 digits); defaults to LISTEN_PORT; used for logging and identification           | 9998                                     |
 
+
+## Key Handlers
+
+Arnika supports multiple key output backends via the `KEY_HANDLER` environment variable. The handler determines how derived PSKs are delivered to their destination.
+
+### WireGuard (default)
+
+The default handler injects PSKs into a standard WireGuard interface via netlink using the [wgctrl](https://pkg.go.dev/golang.zx2c4.com/wireguard/wgctrl) library. WireGuard uses Curve25519 for key exchange with 32-byte keys.
+
+```bash
+KEY_HANDLER=wireguard \
+WIREGUARD_INTERFACE=wg0 \
+WIREGUARD_PEER_PUBLIC_KEY="H9adDtDHXhVzSI4QMScbftvQM49wGjmBT1g6dgynsHc=" \
+arnika
+```
+
+### wolfGuard
+
+[wolfGuard](https://github.com/wolfSSL/wolfGuard) is a FIPS-validated drop-in replacement for WireGuard that uses SECP256R1 (NIST P-256) instead of Curve25519. It registers as a separate generic netlink family (`wolfguard`) and uses 65-byte uncompressed ECC public keys instead of WireGuard's 32-byte keys.
+
+Because the standard `wgctrl` library is hardcoded to the `wireguard` netlink family and 32-byte keys, Arnika includes a dedicated wolfGuard handler that talks directly to the `wolfguard` generic netlink family using the same attribute IDs.
+
+**Requirements:**
+- Linux with the wolfGuard kernel module loaded (`sudo modprobe wolfguard`)
+- wolfSSL kernel module (`libwolfssl.ko`) loaded as a dependency
+- `wg-fips` userspace tool for interface setup (key generation, peer configuration)
+- `CAP_NET_ADMIN` capability
+
+**Interface setup** (using `wg-fips`, not standard `wg`):
+```bash
+# Create wolfGuard interface
+ip link add dev wg0 type wolfguard
+ip addr add 172.16.0.1/24 dev wg0
+
+# Generate keys with wg-fips (requires loaded kernel module)
+sudo wg-fips genkey | tee private.key | sudo wg-fips pubkey > public.key
+
+# Configure interface
+sudo wg-fips set wg0 private-key private.key listen-port 51820
+sudo wg-fips set wg0 peer "$PEER_PUBKEY" allowed-ips 172.16.0.2/32 endpoint 10.0.0.2:51820
+ip link set wg0 up
+```
+
+**Start Arnika with wolfGuard:**
+```bash
+KEY_HANDLER=wolfguard \
+WIREGUARD_INTERFACE=wg0 \
+WIREGUARD_PEER_PUBLIC_KEY="$PEER_PUBKEY" \
+arnika
+```
+
+### MACsec
+
+[MACsec](https://en.wikipedia.org/wiki/IEEE_802.1AE) (IEEE 802.1AE) provides hop-by-hop Layer 2 encryption. Arnika injects 256-bit keys (GCM-AES-256) into MACsec Security Associations (SAs) via the kernel's `macsec` generic netlink family, and switches the active encoding SA via rtnetlink.
+
+**Hitless key rotation:** Arnika performs hitless SA rotation by cycling through association numbers 0-3 with a sliding window of two active SAs (current + previous). This ensures the peer can still decrypt with the old key while transitioning to the new one.
+
+| Step | Inject AN | Delete AN | Active SAs |
+|------|-----------|-----------|------------|
+| 1    | 0         | —         | 0          |
+| 2    | 1         | —         | 0, 1       |
+| 3    | 2         | 0         | 1, 2       |
+| 4    | 3         | 1         | 2, 3       |
+| 5    | 0         | 2         | 3, 0       |
+| 6    | 1         | 3         | 0, 1       |
+
+The RX Secure Channel (SC) for the peer is created automatically on the first key injection if it does not already exist.
+
+**Requirements:**
+- Linux with MACsec support (kernel 4.6+)
+- MACsec interface already created (e.g., via `ip link`)
+- `CAP_NET_ADMIN` capability
+
+**Interface setup:**
+```bash
+# Create MACsec interface on top of a physical interface
+ip link add link eth0 macsec0 type macsec sci 001122334455ffff encrypt on
+
+# Bring it up
+ip link set macsec0 up
+ip addr add 10.0.0.1/24 dev macsec0
+```
+
+**Start Arnika with MACsec:**
+```bash
+KEY_HANDLER=macsec \
+MACSEC_INTERFACE=macsec0 \
+MACSEC_RX_SCI=aabbccddeeff0001 \
+arnika
+```
+
+The `MACSEC_RX_SCI` is the Secure Channel Identifier of the remote peer's transmit SC — typically derived from the peer's MAC address and port number (16 hex characters / 8 bytes).
+
+### File
+
+The file handler writes PSKs to a file on disk, useful for integration with external tools or debugging.
+
+```bash
+KEY_HANDLER=file \
+KEY_OUTPUT_FILE=/tmp/arnika.psk \
+arnika
+```
 
 ---
 

--- a/ci/macsec/setup-namespaces.sh
+++ b/ci/macsec/setup-namespaces.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Sets up two network namespaces (ns-a, ns-b) with MACsec interfaces.
+#
+# Network topology:
+#   ns-a (192.168.100.2) <--veth--> host (192.168.100.1)  [KMS access for node-a]
+#   ns-b (192.168.101.2) <--veth--> host (192.168.101.1)  [KMS access for node-b]
+#   ns-a (10.0.0.1/veth) <--veth--> ns-b (10.0.0.2/veth)  [arnika TCP]
+#   ns-a (172.16.0.1/macsec0) --- MACsec --- ns-b (172.16.0.2/macsec0)
+#
+set -e
+
+# Create namespaces
+ip netns add ns-a
+ip netns add ns-b
+
+# --- veth pair: host <-> ns-a (for KMS access) ---
+ip link add veth-host-a type veth peer name veth-a-host
+ip link set veth-a-host netns ns-a
+ip addr add 192.168.100.1/30 dev veth-host-a
+ip link set veth-host-a up
+ip netns exec ns-a ip addr add 192.168.100.2/30 dev veth-a-host
+ip netns exec ns-a ip link set veth-a-host up
+ip netns exec ns-a ip link set lo up
+
+# --- veth pair: host <-> ns-b (for KMS access) ---
+ip link add veth-host-b type veth peer name veth-b-host
+ip link set veth-b-host netns ns-b
+ip addr add 192.168.101.1/30 dev veth-host-b
+ip link set veth-host-b up
+ip netns exec ns-b ip addr add 192.168.101.2/30 dev veth-b-host
+ip netns exec ns-b ip link set veth-b-host up
+ip netns exec ns-b ip link set lo up
+
+# --- veth pair: ns-a <-> ns-b (underlay for arnika TCP + MACsec) ---
+ip link add veth-a-b type veth peer name veth-b-a
+ip link set veth-a-b netns ns-a
+ip link set veth-b-a netns ns-b
+ip netns exec ns-a ip addr add 10.0.0.1/30 dev veth-a-b
+ip netns exec ns-a ip link set veth-a-b up
+ip netns exec ns-b ip addr add 10.0.0.2/30 dev veth-b-a
+ip netns exec ns-b ip link set veth-b-a up
+
+# --- MACsec interfaces on top of the peer-to-peer veth ---
+# Get MAC addresses for SCI derivation
+MAC_A=$(ip netns exec ns-a cat /sys/class/net/veth-a-b/address | tr -d ':')
+MAC_B=$(ip netns exec ns-b cat /sys/class/net/veth-b-a/address | tr -d ':')
+# SCI = MAC (6 bytes) + port (2 bytes, we use 0001)
+SCI_A="${MAC_A}0001"
+SCI_B="${MAC_B}0001"
+
+# node-a macsec0 (encrypt on, using node-a's SCI)
+ip netns exec ns-a ip link add link veth-a-b macsec0 type macsec \
+    sci "${SCI_A}" encrypt on
+ip netns exec ns-a ip addr add 172.16.0.1/24 dev macsec0
+ip netns exec ns-a ip link set macsec0 up
+
+# node-b macsec0 (encrypt on, using node-b's SCI)
+ip netns exec ns-b ip link add link veth-b-a macsec0 type macsec \
+    sci "${SCI_B}" encrypt on
+ip netns exec ns-b ip addr add 172.16.0.2/24 dev macsec0
+ip netns exec ns-b ip link set macsec0 up
+
+# Save SCIs for use by start-nodes.sh
+echo -n "$SCI_A" > /tmp/macsec-test/sci-a
+echo -n "$SCI_B" > /tmp/macsec-test/sci-b
+
+echo "Network namespaces and MACsec interfaces configured"
+echo "  ns-a macsec0: 172.16.0.1 (SCI: ${SCI_A})"
+echo "  ns-b macsec0: 172.16.0.2 (SCI: ${SCI_B})"

--- a/ci/macsec/start-nodes.sh
+++ b/ci/macsec/start-nodes.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Starts arnika in both namespaces: node-a as MASTER, node-b as BACKUP.
+# Each node uses KEY_HANDLER=macsec with the peer's SCI as MACSEC_RX_SCI.
+set -e
+
+ARNIKA="$(pwd)/build/arnika"
+SCI_A=$(cat /tmp/macsec-test/sci-a)
+SCI_B=$(cat /tmp/macsec-test/sci-b)
+
+# Start node-a (MASTER) — receives from node-b, so RX SCI = node-b's SCI
+ip netns exec ns-a env \
+    LISTEN_ADDRESS=10.0.0.1:9998 \
+    SERVER_ADDRESS=10.0.0.2:9998 \
+    INTERVAL=5s \
+    KMS_URL="http://192.168.100.1:8080/api/v1/keys/CONSB" \
+    KEY_HANDLER=macsec \
+    MACSEC_INTERFACE=macsec0 \
+    MACSEC_RX_SCI="$SCI_B" \
+    "$ARNIKA" &> /tmp/macsec-test/node-a/arnika.log &
+echo $! > /tmp/macsec-test/node-a/arnika.pid
+echo "Started arnika node-a (MASTER) pid=$(cat /tmp/macsec-test/node-a/arnika.pid)"
+
+# Start node-b (BACKUP) — receives from node-a, so RX SCI = node-a's SCI
+ip netns exec ns-b env \
+    LISTEN_ADDRESS=10.0.0.2:9998 \
+    SERVER_ADDRESS=10.0.0.1:9998 \
+    INTERVAL=5s \
+    KMS_URL="http://192.168.101.1:8080/api/v1/keys/CONSB" \
+    KEY_HANDLER=macsec \
+    MACSEC_INTERFACE=macsec0 \
+    MACSEC_RX_SCI="$SCI_A" \
+    "$ARNIKA" &> /tmp/macsec-test/node-b/arnika.log &
+echo $! > /tmp/macsec-test/node-b/arnika.pid
+echo "Started arnika node-b (BACKUP) pid=$(cat /tmp/macsec-test/node-b/arnika.pid)"

--- a/ci/macsec/verify.sh
+++ b/ci/macsec/verify.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Verifies that arnika successfully injected matching SAKs into MACsec interfaces.
+set -e
+
+echo "====== MACsec Integration Test - Verification ======"
+
+echo "Waiting for key exchange (30 seconds)..."
+sleep 30
+
+# Dump MACsec state from both namespaces
+ip netns exec ns-a ip macsec show > /tmp/macsec-test/macsec-a.txt 2>&1
+ip netns exec ns-b ip macsec show > /tmp/macsec-test/macsec-b.txt 2>&1
+
+echo ""
+echo "====== MACsec State (ns-a) ======"
+cat /tmp/macsec-test/macsec-a.txt
+
+echo ""
+echo "====== MACsec State (ns-b) ======"
+cat /tmp/macsec-test/macsec-b.txt
+
+echo ""
+echo "====== Verification Results ======"
+
+# Check that node-a has at least one active TX SA
+if ! grep -q "TXSA:" /tmp/macsec-test/macsec-a.txt; then
+    echo "FAILED: Node-A has no TX SA configured"
+    cat /tmp/macsec-test/node-a/arnika.log || true
+    exit 1
+fi
+echo "OK: Node-A has TX SA configured"
+
+# Check that node-b has at least one active TX SA
+if ! grep -q "TXSA:" /tmp/macsec-test/macsec-b.txt; then
+    echo "FAILED: Node-B has no TX SA configured"
+    cat /tmp/macsec-test/node-b/arnika.log || true
+    exit 1
+fi
+echo "OK: Node-B has TX SA configured"
+
+# Check that node-a has an RX SC (from node-b)
+if ! grep -q "RXSC:" /tmp/macsec-test/macsec-a.txt; then
+    echo "FAILED: Node-A has no RX SC configured"
+    exit 1
+fi
+echo "OK: Node-A has RX SC configured"
+
+# Check that node-b has an RX SC (from node-a)
+if ! grep -q "RXSC:" /tmp/macsec-test/macsec-b.txt; then
+    echo "FAILED: Node-B has no RX SC configured"
+    exit 1
+fi
+echo "OK: Node-B has RX SC configured"
+
+echo ""
+echo "====== Tunnel Connectivity ======"
+if ip netns exec ns-a ping -c 3 -W 2 172.16.0.2 > /dev/null 2>&1; then
+    echo "SUCCESS: Node-A can ping Node-B through MACsec tunnel"
+else
+    echo "WARNING: Tunnel ping failed (may need more time for SA sync)"
+fi
+
+echo ""
+echo "SUCCESS: MACsec SAs configured on both nodes"
+exit 0

--- a/ci/wolfguard/setup-namespaces.sh
+++ b/ci/wolfguard/setup-namespaces.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Sets up two network namespaces (ns-a, ns-b) connected via veth pairs.
+#
+# Network topology:
+#   ns-a (192.168.100.2) <--veth--> host (192.168.100.1)  [KMS access for node-a]
+#   ns-b (192.168.101.2) <--veth--> host (192.168.101.1)  [KMS access for node-b]
+#   ns-a (10.0.0.1)      <--veth--> ns-b (10.0.0.2)       [arnika TCP + WireGuard]
+#
+set -e
+
+# Create namespaces
+ip netns add ns-a
+ip netns add ns-b
+
+# --- veth pair: host <-> ns-a (for KMS access) ---
+ip link add veth-host-a type veth peer name veth-a-host
+ip link set veth-a-host netns ns-a
+ip addr add 192.168.100.1/30 dev veth-host-a
+ip link set veth-host-a up
+ip netns exec ns-a ip addr add 192.168.100.2/30 dev veth-a-host
+ip netns exec ns-a ip link set veth-a-host up
+ip netns exec ns-a ip link set lo up
+
+# --- veth pair: host <-> ns-b (for KMS access) ---
+ip link add veth-host-b type veth peer name veth-b-host
+ip link set veth-b-host netns ns-b
+ip addr add 192.168.101.1/30 dev veth-host-b
+ip link set veth-host-b up
+ip netns exec ns-b ip addr add 192.168.101.2/30 dev veth-b-host
+ip netns exec ns-b ip link set veth-b-host up
+ip netns exec ns-b ip link set lo up
+
+# --- veth pair: ns-a <-> ns-b (for arnika TCP + WireGuard endpoint) ---
+ip link add veth-a-b type veth peer name veth-b-a
+ip link set veth-a-b netns ns-a
+ip link set veth-b-a netns ns-b
+ip netns exec ns-a ip addr add 10.0.0.1/30 dev veth-a-b
+ip netns exec ns-a ip link set veth-a-b up
+ip netns exec ns-b ip addr add 10.0.0.2/30 dev veth-b-a
+ip netns exec ns-b ip link set veth-b-a up
+
+# --- WireGuard interfaces (using wolfGuard kernel module) ---
+PUBKEY_A=$(cat /tmp/wolfguard-test/node-a/public.key)
+PUBKEY_B=$(cat /tmp/wolfguard-test/node-b/public.key)
+
+# node-a wg0
+ip netns exec ns-a ip link add dev wg0 type wolfguard
+ip netns exec ns-a ip addr add 172.16.0.1/24 dev wg0
+ip netns exec ns-a wg-fips set wg0 \
+    private-key /tmp/wolfguard-test/node-a/private.key \
+    listen-port 51820
+ip netns exec ns-a wg-fips set wg0 \
+    peer "$PUBKEY_B" \
+    allowed-ips 172.16.0.2/32 \
+    endpoint 10.0.0.2:51820
+ip netns exec ns-a ip link set wg0 up
+
+# node-b wg0
+ip netns exec ns-b ip link add dev wg0 type wolfguard
+ip netns exec ns-b ip addr add 172.16.0.2/24 dev wg0
+ip netns exec ns-b wg-fips set wg0 \
+    private-key /tmp/wolfguard-test/node-b/private.key \
+    listen-port 51820
+ip netns exec ns-b wg-fips set wg0 \
+    peer "$PUBKEY_A" \
+    allowed-ips 172.16.0.1/32 \
+    endpoint 10.0.0.1:51820
+ip netns exec ns-b ip link set wg0 up
+
+echo "Network namespaces and WireGuard interfaces configured"
+echo "  ns-a wg0: 172.16.0.1 (wolfGuard)"
+echo "  ns-b wg0: 172.16.0.2 (wolfGuard)"

--- a/ci/wolfguard/start-nodes.sh
+++ b/ci/wolfguard/start-nodes.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Starts arnika in both namespaces: node-a as MASTER, node-b as BACKUP.
+set -e
+
+ARNIKA="$(pwd)/build/arnika"
+PUBKEY_A=$(cat /tmp/wolfguard-test/node-a/public.key)
+PUBKEY_B=$(cat /tmp/wolfguard-test/node-b/public.key)
+
+# Start node-a (MASTER)
+ip netns exec ns-a env \
+    LISTEN_ADDRESS=10.0.0.1:9998 \
+    SERVER_ADDRESS=10.0.0.2:9998 \
+    INTERVAL=5s \
+    KMS_URL="http://192.168.100.1:8080/api/v1/keys/CONSB" \
+    KEY_HANDLER=wolfguard \
+    WIREGUARD_INTERFACE=wg0 \
+    WIREGUARD_PEER_PUBLIC_KEY="$PUBKEY_B" \
+    "$ARNIKA" &> /tmp/wolfguard-test/node-a/arnika.log &
+echo $! > /tmp/wolfguard-test/node-a/arnika.pid
+echo "Started arnika node-a (MASTER) pid=$(cat /tmp/wolfguard-test/node-a/arnika.pid)"
+
+# Start node-b (BACKUP)
+ip netns exec ns-b env \
+    LISTEN_ADDRESS=10.0.0.2:9998 \
+    SERVER_ADDRESS=10.0.0.1:9998 \
+    INTERVAL=5s \
+    KMS_URL="http://192.168.101.1:8080/api/v1/keys/CONSB" \
+    KEY_HANDLER=wolfguard \
+    WIREGUARD_INTERFACE=wg0 \
+    WIREGUARD_PEER_PUBLIC_KEY="$PUBKEY_A" \
+    "$ARNIKA" &> /tmp/wolfguard-test/node-b/arnika.log &
+echo $! > /tmp/wolfguard-test/node-b/arnika.pid
+echo "Started arnika node-b (BACKUP) pid=$(cat /tmp/wolfguard-test/node-b/arnika.pid)"

--- a/ci/wolfguard/verify.sh
+++ b/ci/wolfguard/verify.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Verifies that arnika successfully injected matching PSKs into wolfGuard interfaces.
+set -e
+
+echo "====== wolfGuard Integration Test - Verification ======"
+
+echo "Waiting for key exchange (30 seconds)..."
+sleep 30
+
+# Extract PSKs
+PSK_A=$(ip netns exec ns-a wg-fips show wg0 preshared-keys | awk '{print $2}')
+PSK_B=$(ip netns exec ns-b wg-fips show wg0 preshared-keys | awk '{print $2}')
+
+echo "Node-A PSK: ${PSK_A}"
+echo "Node-B PSK: ${PSK_B}"
+
+echo ""
+echo "====== Verification Results ======"
+
+if [ -z "$PSK_A" ] || [ "$PSK_A" = "(none)" ]; then
+    echo "FAILED: Node-A has no PSK configured"
+    exit 1
+fi
+
+if [ -z "$PSK_B" ] || [ "$PSK_B" = "(none)" ]; then
+    echo "FAILED: Node-B has no PSK configured"
+    exit 1
+fi
+
+if [ "$PSK_A" = "$PSK_B" ]; then
+    echo "SUCCESS: Both wolfGuard nodes have the same PSK"
+    echo "PSK: ${PSK_A}"
+
+    echo ""
+    echo "====== Tunnel Connectivity ======"
+    if ip netns exec ns-a ping -c 3 -W 2 172.16.0.2 > /dev/null 2>&1; then
+        echo "SUCCESS: Node-A can ping Node-B through wolfGuard tunnel"
+    else
+        echo "WARNING: Tunnel ping failed (may need more time)"
+    fi
+
+    echo ""
+    echo "====== wolfGuard Interface Info ======"
+    echo "--- ns-a ---"
+    ip netns exec ns-a wg-fips show wg0
+    echo "--- ns-b ---"
+    ip netns exec ns-b wg-fips show wg0
+
+    exit 0
+else
+    echo "FAILED: PSKs do not match"
+    echo "Node-A PSK: ${PSK_A}"
+    echo "Node-B PSK: ${PSK_B}"
+
+    echo ""
+    echo "====== Debug Logs ======"
+    echo "--- Node-A ---"
+    cat /tmp/wolfguard-test/node-a/arnika.log || true
+    echo "--- Node-B ---"
+    cat /tmp/wolfguard-test/node-b/arnika.log || true
+
+    exit 1
+fi

--- a/config/config.go
+++ b/config/config.go
@@ -22,10 +22,12 @@ type Config struct {
 	KMSBackoffBaseDelay    time.Duration // KMS_BACKOFF_BASE_DELAY, Base delay for KMS request retries, will get exponentially increased
 	KMSRetryInterval       time.Duration // KMS_RETRY_INTERVAL, Interval between KMS request retries
 	Interval               time.Duration // INTERVAL, Interval between key updates
-	KeyHandler             string        // KEY_HANDLER, Key output handler ("wireguard", "wolfguard", "file")
+	KeyHandler             string        // KEY_HANDLER, Key output handler ("wireguard", "wolfguard", "macsec", "file")
 	WireGuardInterface     string        // WIREGUARD_INTERFACE, Name of the WireGuard interface to configure
 	WireguardPeerPublicKey string        // WIREGUARD_PEER_PUBLIC_KEY, Public key of the WireGuard peer
 	KeyOutputFile          string        // KEY_OUTPUT_FILE, Path to write the PSK when KEY_HANDLER is "file"
+	MACsecInterface        string        // MACSEC_INTERFACE, Name of the MACsec interface
+	MACsecRxSCI            string        // MACSEC_RX_SCI, Peer's Secure Channel Identifier (16 hex chars)
 	PQCPSKFile             string        // PQC_PSK_FILE, Path to the PQC PSK file
 	Mode                   string        // MODE, Operation mode ("QkdAndPqcRequired", "AtLeastQkdRequired", "AtLeastPqcRequired", "EitherQkdOrPqcRequired")
 }
@@ -86,6 +88,10 @@ func (c *Config) PrintStartupConfig() {
 		fmt.Printf("WireGuard Interface:      %s\n", c.WireGuardInterface)
 		fmt.Printf("WireGuard Peer PublicKey: %s\n", c.WireguardPeerPublicKey)
 	}
+	if c.KeyHandler == "macsec" {
+		fmt.Printf("MACsec Interface:        %s\n", c.MACsecInterface)
+		fmt.Printf("MACsec RX SCI:           %s\n", c.MACsecRxSCI)
+	}
 	if c.KeyHandler == "file" {
 		fmt.Printf("Key Output File:         %s\n", c.KeyOutputFile)
 	}
@@ -144,8 +150,8 @@ func Parse() (*Config, error) {
 	}
 	config.Interval = interval
 	config.KeyHandler = getEnvOrDefault("KEY_HANDLER", "wireguard")
-	if config.KeyHandler != "wireguard" && config.KeyHandler != "wolfguard" && config.KeyHandler != "file" {
-		return nil, fmt.Errorf("[ERROR] invalid KEY_HANDLER value: %s (must be wireguard, wolfguard, or file)", config.KeyHandler)
+	if config.KeyHandler != "wireguard" && config.KeyHandler != "wolfguard" && config.KeyHandler != "macsec" && config.KeyHandler != "file" {
+		return nil, fmt.Errorf("[ERROR] invalid KEY_HANDLER value: %s (must be wireguard, wolfguard, macsec, or file)", config.KeyHandler)
 	}
 	if config.KeyHandler == "wireguard" || config.KeyHandler == "wolfguard" {
 		config.WireGuardInterface, err = getEnv("WIREGUARD_INTERFACE")
@@ -155,6 +161,19 @@ func Parse() (*Config, error) {
 		config.WireguardPeerPublicKey, err = getEnv("WIREGUARD_PEER_PUBLIC_KEY")
 		if err != nil {
 			return nil, err
+		}
+	}
+	if config.KeyHandler == "macsec" {
+		config.MACsecInterface, err = getEnv("MACSEC_INTERFACE")
+		if err != nil {
+			return nil, err
+		}
+		config.MACsecRxSCI, err = getEnv("MACSEC_RX_SCI")
+		if err != nil {
+			return nil, err
+		}
+		if len(config.MACsecRxSCI) != 16 {
+			return nil, fmt.Errorf("[ERROR] MACSEC_RX_SCI must be 16 hex characters, got %d", len(config.MACsecRxSCI))
 		}
 	}
 	if config.KeyHandler == "file" {

--- a/config/config.go
+++ b/config/config.go
@@ -22,8 +22,10 @@ type Config struct {
 	KMSBackoffBaseDelay    time.Duration // KMS_BACKOFF_BASE_DELAY, Base delay for KMS request retries, will get exponentially increased
 	KMSRetryInterval       time.Duration // KMS_RETRY_INTERVAL, Interval between KMS request retries
 	Interval               time.Duration // INTERVAL, Interval between key updates
+	KeyHandler             string        // KEY_HANDLER, Key output handler ("wireguard", "file")
 	WireGuardInterface     string        // WIREGUARD_INTERFACE, Name of the WireGuard interface to configure
 	WireguardPeerPublicKey string        // WIREGUARD_PEER_PUBLIC_KEY, Public key of the WireGuard peer
+	KeyOutputFile          string        // KEY_OUTPUT_FILE, Path to write the PSK when KEY_HANDLER is "file"
 	PQCPSKFile             string        // PQC_PSK_FILE, Path to the PQC PSK file
 	Mode                   string        // MODE, Operation mode ("QkdAndPqcRequired", "AtLeastQkdRequired", "AtLeastPqcRequired", "EitherQkdOrPqcRequired")
 }
@@ -79,8 +81,14 @@ func (c *Config) PrintStartupConfig() {
 		fmt.Println("PQC key provider:        DISABLED")
 	}
 
-	fmt.Printf("WireGuard Interface:      %s\n", c.WireGuardInterface)
-	fmt.Printf("WireGuard Peer PublicKey: %s\n", c.WireguardPeerPublicKey)
+	fmt.Printf("Key Handler:             %s\n", c.KeyHandler)
+	if c.KeyHandler == "wireguard" {
+		fmt.Printf("WireGuard Interface:      %s\n", c.WireGuardInterface)
+		fmt.Printf("WireGuard Peer PublicKey: %s\n", c.WireguardPeerPublicKey)
+	}
+	if c.KeyHandler == "file" {
+		fmt.Printf("Key Output File:         %s\n", c.KeyOutputFile)
+	}
 	fmt.Println("============================")
 }
 
@@ -135,13 +143,25 @@ func Parse() (*Config, error) {
 		return nil, fmt.Errorf("[ERROR] failed to parse INTERVAL: %w", err)
 	}
 	config.Interval = interval
-	config.WireGuardInterface, err = getEnv("WIREGUARD_INTERFACE")
-	if err != nil {
-		return nil, err
+	config.KeyHandler = getEnvOrDefault("KEY_HANDLER", "wireguard")
+	if config.KeyHandler != "wireguard" && config.KeyHandler != "file" {
+		return nil, fmt.Errorf("[ERROR] invalid KEY_HANDLER value: %s (must be wireguard or file)", config.KeyHandler)
 	}
-	config.WireguardPeerPublicKey, err = getEnv("WIREGUARD_PEER_PUBLIC_KEY")
-	if err != nil {
-		return nil, err
+	if config.KeyHandler == "wireguard" {
+		config.WireGuardInterface, err = getEnv("WIREGUARD_INTERFACE")
+		if err != nil {
+			return nil, err
+		}
+		config.WireguardPeerPublicKey, err = getEnv("WIREGUARD_PEER_PUBLIC_KEY")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if config.KeyHandler == "file" {
+		config.KeyOutputFile, err = getEnv("KEY_OUTPUT_FILE")
+		if err != nil {
+			return nil, err
+		}
 	}
 	config.PQCPSKFile = getEnvOrDefault("PQC_PSK_FILE", "")
 	if config.PQCPSKFile != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	KMSBackoffBaseDelay    time.Duration // KMS_BACKOFF_BASE_DELAY, Base delay for KMS request retries, will get exponentially increased
 	KMSRetryInterval       time.Duration // KMS_RETRY_INTERVAL, Interval between KMS request retries
 	Interval               time.Duration // INTERVAL, Interval between key updates
-	KeyHandler             string        // KEY_HANDLER, Key output handler ("wireguard", "file")
+	KeyHandler             string        // KEY_HANDLER, Key output handler ("wireguard", "wolfguard", "file")
 	WireGuardInterface     string        // WIREGUARD_INTERFACE, Name of the WireGuard interface to configure
 	WireguardPeerPublicKey string        // WIREGUARD_PEER_PUBLIC_KEY, Public key of the WireGuard peer
 	KeyOutputFile          string        // KEY_OUTPUT_FILE, Path to write the PSK when KEY_HANDLER is "file"
@@ -82,7 +82,7 @@ func (c *Config) PrintStartupConfig() {
 	}
 
 	fmt.Printf("Key Handler:             %s\n", c.KeyHandler)
-	if c.KeyHandler == "wireguard" {
+	if c.KeyHandler == "wireguard" || c.KeyHandler == "wolfguard" {
 		fmt.Printf("WireGuard Interface:      %s\n", c.WireGuardInterface)
 		fmt.Printf("WireGuard Peer PublicKey: %s\n", c.WireguardPeerPublicKey)
 	}
@@ -144,10 +144,10 @@ func Parse() (*Config, error) {
 	}
 	config.Interval = interval
 	config.KeyHandler = getEnvOrDefault("KEY_HANDLER", "wireguard")
-	if config.KeyHandler != "wireguard" && config.KeyHandler != "file" {
-		return nil, fmt.Errorf("[ERROR] invalid KEY_HANDLER value: %s (must be wireguard or file)", config.KeyHandler)
+	if config.KeyHandler != "wireguard" && config.KeyHandler != "wolfguard" && config.KeyHandler != "file" {
+		return nil, fmt.Errorf("[ERROR] invalid KEY_HANDLER value: %s (must be wireguard, wolfguard, or file)", config.KeyHandler)
 	}
-	if config.KeyHandler == "wireguard" {
+	if config.KeyHandler == "wireguard" || config.KeyHandler == "wolfguard" {
 		config.WireGuardInterface, err = getEnv("WIREGUARD_INTERFACE")
 		if err != nil {
 			return nil, err

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -55,9 +55,10 @@ func TestParse(t *testing.T) {
 		KMSURL:                 "https://example.com",
 		Interval:               time.Second * 10,       // Default value for Interval
 		KMSHTTPTimeout:         time.Second * 10,       // Default value for KMSHTTPTimeout
-		KMSBackoffMaxRetries:  5,                      // Default value for KMSBackoffMaxRetries
+		KMSBackoffMaxRetries:   5,                      // Default value for KMSBackoffMaxRetries
 		KMSBackoffBaseDelay:    time.Millisecond * 100, // Default value for KMSBackoffBaseDelay
 		KMSRetryInterval:       (time.Second * 10) / 2, // Default value for KMSRetryInterval
+		KeyHandler:             "wireguard",             // Default value for KeyHandler
 		WireGuardInterface:     "wg0",
 		WireguardPeerPublicKey: "H9adDtDHXhVzSI4QMScbftvQM49wGjmBT1g6dgynsHc=",
 		PQCPSKFile:             "", // Default value for PQCPSKFile

--- a/go.mod
+++ b/go.mod
@@ -5,18 +5,18 @@ go 1.24.13
 
 require (
 	github.com/google/uuid v1.6.0
+	github.com/mdlayher/genetlink v1.3.2
+	github.com/mdlayher/netlink v1.7.2
 	golang.org/x/crypto v0.45.0
+	golang.org/x/sys v0.38.0
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230429144221-925a1e7659e6
 )
 
 require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/josharian/native v1.1.0 // indirect
-	github.com/mdlayher/genetlink v1.3.2 // indirect
-	github.com/mdlayher/netlink v1.7.2 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 // indirect
 )

--- a/keyhandler/file.go
+++ b/keyhandler/file.go
@@ -1,0 +1,32 @@
+package keyhandler
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"os"
+)
+
+// File writes PSKs to a file on disk.
+type File struct {
+	path string
+}
+
+func NewFile(path string) (*File, error) {
+	if path == "" {
+		return nil, fmt.Errorf("KEY_OUTPUT_FILE is required when KEY_HANDLER is set to file")
+	}
+	return &File{path: path}, nil
+}
+
+func (f *File) SetKey(psk string) error {
+	return os.WriteFile(f.path, []byte(psk+"\n"), 0600)
+}
+
+func (f *File) Invalidate() error {
+	var key [32]byte
+	if _, err := rand.Read(key[:]); err != nil {
+		return fmt.Errorf("failed to generate random key: %w", err)
+	}
+	return f.SetKey(base64.StdEncoding.EncodeToString(key[:]))
+}

--- a/keyhandler/handler.go
+++ b/keyhandler/handler.go
@@ -1,0 +1,11 @@
+package keyhandler
+
+// Handler defines how derived PSKs are delivered to their destination.
+type Handler interface {
+	// SetKey delivers a PSK (base64-encoded) to the configured output.
+	SetKey(psk string) error
+
+	// Invalidate writes a random key to the output, invalidating
+	// any existing session that relies on the previous key.
+	Invalidate() error
+}

--- a/keyhandler/macsec_linux.go
+++ b/keyhandler/macsec_linux.go
@@ -1,0 +1,301 @@
+//go:build linux
+
+package keyhandler
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"net"
+
+	"github.com/mdlayher/genetlink"
+	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// MACsec genetlink constants from linux/if_macsec.h.
+const (
+	macsecGenlName = "macsec"
+
+	macsecCmdAddRxsc = 1
+	macsecCmdAddTxsa = 4
+	macsecCmdDelTxsa = 5
+	macsecCmdAddRxsa = 7
+	macsecCmdDelRxsa = 8
+
+	macsecAttrIfindex    = 1
+	macsecAttrRxscConfig = 3
+	macsecAttrSaConfig   = 4
+
+	macsecRxscAttrSci    = 1
+	macsecRxscAttrActive = 2
+
+	macsecSaAttrAn     = 1
+	macsecSaAttrActive = 2
+	macsecSaAttrPn     = 3
+	macsecSaAttrKey    = 4
+	macsecSaAttrKeyid  = 5
+
+	// rtnetlink: IFLA_MACSEC_ENCODING_SA from linux/if_link.h.
+	iflaMacsecEncodingSA = 6
+)
+
+// MACsec injects keys into a MACsec interface via genetlink with hitless
+// SA rotation. It maintains a sliding window of 2 active SAs (current +
+// previous), cycling through association numbers 0-3.
+//
+// Rotation sequence:
+//
+//	Step 1: inject AN 0                → active: {0}
+//	Step 2: inject AN 1                → active: {0, 1}
+//	Step 3: inject AN 2, delete AN 0   → active: {1, 2}
+//	Step 4: inject AN 3, delete AN 1   → active: {2, 3}
+//	Step 5: inject AN 0, delete AN 2   → active: {3, 0}
+type MACsec struct {
+	gc      *genetlink.Conn
+	family  genetlink.Family
+	ifIndex int
+	rxSCI   uint64
+	calls   int // number of SetKey calls so far
+}
+
+func NewMACsec(interfaceName, rxSCI string) (*MACsec, error) {
+	gc, err := genetlink.Dial(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open genetlink: %w", err)
+	}
+
+	f, err := gc.GetFamily(macsecGenlName)
+	if err != nil {
+		_ = gc.Close()
+		return nil, fmt.Errorf("macsec netlink family not found: %w", err)
+	}
+
+	iface, err := net.InterfaceByName(interfaceName)
+	if err != nil {
+		_ = gc.Close()
+		return nil, fmt.Errorf("interface %s not found: %w", interfaceName, err)
+	}
+
+	sciBytes, err := hex.DecodeString(rxSCI)
+	if err != nil || len(sciBytes) != 8 {
+		_ = gc.Close()
+		return nil, fmt.Errorf("MACSEC_RX_SCI must be 16 hex characters (8 bytes), got %q", rxSCI)
+	}
+
+	return &MACsec{
+		gc:      gc,
+		family:  f,
+		ifIndex: iface.Index,
+		rxSCI:   binary.BigEndian.Uint64(sciBytes),
+	}, nil
+}
+
+func (m *MACsec) SetKey(psk string) error {
+	keyBytes, err := base64.StdEncoding.DecodeString(psk)
+	if err != nil {
+		return fmt.Errorf("failed to decode PSK: %w", err)
+	}
+	if len(keyBytes) != 32 {
+		return fmt.Errorf("PSK must be 32 bytes, got %d", len(keyBytes))
+	}
+
+	keyIDFull := sha256.Sum256(keyBytes)
+	keyID := keyIDFull[:16]
+
+	nextAN := uint8(m.calls % 4)
+
+	// From the 3rd call onward, delete the SA two steps behind.
+	if m.calls >= 2 {
+		staleAN := uint8((m.calls - 2) % 4)
+		_ = m.deleteTxSA(staleAN)
+		_ = m.deleteRxSA(staleAN)
+	}
+
+	if err := m.ensureRxSC(); err != nil {
+		return fmt.Errorf("failed to ensure RX SC: %w", err)
+	}
+
+	if err := m.addTxSA(nextAN, keyBytes, keyID); err != nil {
+		return fmt.Errorf("failed to add TX SA %d: %w", nextAN, err)
+	}
+	if err := m.addRxSA(nextAN, keyBytes, keyID); err != nil {
+		return fmt.Errorf("failed to add RX SA %d: %w", nextAN, err)
+	}
+
+	if err := m.setEncodingSA(nextAN); err != nil {
+		return fmt.Errorf("failed to set encoding SA to %d: %w", nextAN, err)
+	}
+
+	m.calls++
+	return nil
+}
+
+func (m *MACsec) Invalidate() error {
+	var key [32]byte
+	if _, err := rand.Read(key[:]); err != nil {
+		return fmt.Errorf("failed to generate random key: %w", err)
+	}
+	return m.SetKey(base64.StdEncoding.EncodeToString(key[:]))
+}
+
+// SA management via macsec genetlink.
+
+func (m *MACsec) addTxSA(an uint8, key, keyID []byte) error {
+	ae := netlink.NewAttributeEncoder()
+	ae.Uint32(macsecAttrIfindex, uint32(m.ifIndex))
+	ae.Nested(macsecAttrSaConfig, encodeSAConfig(an, key, keyID))
+	attrs, err := ae.Encode()
+	if err != nil {
+		return err
+	}
+	_, err = m.execute(macsecCmdAddTxsa, netlink.Request|netlink.Acknowledge, attrs)
+	return err
+}
+
+func (m *MACsec) addRxSA(an uint8, key, keyID []byte) error {
+	ae := netlink.NewAttributeEncoder()
+	ae.Uint32(macsecAttrIfindex, uint32(m.ifIndex))
+	ae.Nested(macsecAttrSaConfig, encodeSAConfig(an, key, keyID))
+	ae.Nested(macsecAttrRxscConfig, func(nae *netlink.AttributeEncoder) error {
+		nae.Uint64(macsecRxscAttrSci, m.rxSCI)
+		return nil
+	})
+	attrs, err := ae.Encode()
+	if err != nil {
+		return err
+	}
+	_, err = m.execute(macsecCmdAddRxsa, netlink.Request|netlink.Acknowledge, attrs)
+	return err
+}
+
+func (m *MACsec) deleteTxSA(an uint8) error {
+	return m.deleteSA(macsecCmdDelTxsa, an)
+}
+
+func (m *MACsec) deleteRxSA(an uint8) error {
+	ae := netlink.NewAttributeEncoder()
+	ae.Uint32(macsecAttrIfindex, uint32(m.ifIndex))
+	ae.Nested(macsecAttrSaConfig, func(nae *netlink.AttributeEncoder) error {
+		nae.Uint8(macsecSaAttrAn, an)
+		return nil
+	})
+	ae.Nested(macsecAttrRxscConfig, func(nae *netlink.AttributeEncoder) error {
+		nae.Uint64(macsecRxscAttrSci, m.rxSCI)
+		return nil
+	})
+	attrs, err := ae.Encode()
+	if err != nil {
+		return err
+	}
+	_, err = m.execute(macsecCmdDelRxsa, netlink.Request|netlink.Acknowledge, attrs)
+	return err
+}
+
+func (m *MACsec) deleteSA(command uint8, an uint8) error {
+	ae := netlink.NewAttributeEncoder()
+	ae.Uint32(macsecAttrIfindex, uint32(m.ifIndex))
+	ae.Nested(macsecAttrSaConfig, func(nae *netlink.AttributeEncoder) error {
+		nae.Uint8(macsecSaAttrAn, an)
+		return nil
+	})
+	attrs, err := ae.Encode()
+	if err != nil {
+		return err
+	}
+	_, err = m.execute(command, netlink.Request|netlink.Acknowledge, attrs)
+	return err
+}
+
+func (m *MACsec) ensureRxSC() error {
+	ae := netlink.NewAttributeEncoder()
+	ae.Uint32(macsecAttrIfindex, uint32(m.ifIndex))
+	ae.Nested(macsecAttrRxscConfig, func(nae *netlink.AttributeEncoder) error {
+		nae.Uint64(macsecRxscAttrSci, m.rxSCI)
+		nae.Uint8(macsecRxscAttrActive, 1)
+		return nil
+	})
+	attrs, err := ae.Encode()
+	if err != nil {
+		return err
+	}
+	_, err = m.execute(macsecCmdAddRxsc, netlink.Request|netlink.Acknowledge, attrs)
+	if isErrExist(err) {
+		return nil
+	}
+	return err
+}
+
+// encoding SA via rtnetlink.
+
+func (m *MACsec) setEncodingSA(an uint8) error {
+	rc, err := netlink.Dial(unix.NETLINK_ROUTE, nil)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	ae := netlink.NewAttributeEncoder()
+	ae.Nested(unix.IFLA_LINKINFO, func(nae *netlink.AttributeEncoder) error {
+		nae.String(unix.IFLA_INFO_KIND, "macsec")
+		nae.Nested(unix.IFLA_INFO_DATA, func(nnae *netlink.AttributeEncoder) error {
+			nnae.Uint8(iflaMacsecEncodingSA, an)
+			return nil
+		})
+		return nil
+	})
+	attrBytes, err := ae.Encode()
+	if err != nil {
+		return err
+	}
+
+	ifinfo := make([]byte, unix.SizeofIfInfomsg)
+	binary.NativeEndian.PutUint32(ifinfo[4:8], uint32(m.ifIndex))
+
+	_, err = rc.Execute(netlink.Message{
+		Header: netlink.Header{
+			Type:  unix.RTM_SETLINK,
+			Flags: netlink.Request | netlink.Acknowledge,
+		},
+		Data: append(ifinfo, attrBytes...),
+	})
+	return err
+}
+
+// helpers.
+
+func encodeSAConfig(an uint8, key, keyID []byte) func(*netlink.AttributeEncoder) error {
+	return func(nae *netlink.AttributeEncoder) error {
+		nae.Uint8(macsecSaAttrAn, an)
+		nae.Uint32(macsecSaAttrPn, 1)
+		nae.Bytes(macsecSaAttrKey, key)
+		nae.Bytes(macsecSaAttrKeyid, keyID)
+		nae.Uint8(macsecSaAttrActive, 1)
+		return nil
+	}
+}
+
+func (m *MACsec) execute(command uint8, flags netlink.HeaderFlags, attrb []byte) ([]genetlink.Message, error) {
+	msg := genetlink.Message{
+		Header: genetlink.Header{
+			Command: command,
+			Version: 1,
+		},
+		Data: attrb,
+	}
+	return m.gc.Execute(msg, m.family.ID, flags)
+}
+
+func isErrExist(err error) bool {
+	if err == nil {
+		return false
+	}
+	oerr, ok := err.(*netlink.OpError)
+	if !ok {
+		return false
+	}
+	return oerr.Err == unix.EEXIST
+}

--- a/keyhandler/macsec_stub.go
+++ b/keyhandler/macsec_stub.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package keyhandler
+
+import "fmt"
+
+type MACsec struct{}
+
+func NewMACsec(interfaceName, rxSCI string) (*MACsec, error) {
+	return nil, fmt.Errorf("macsec is only supported on Linux")
+}
+
+func (m *MACsec) SetKey(psk string) error { return fmt.Errorf("macsec: not supported") }
+func (m *MACsec) Invalidate() error       { return fmt.Errorf("macsec: not supported") }

--- a/keyhandler/wireguard.go
+++ b/keyhandler/wireguard.go
@@ -1,0 +1,69 @@
+package keyhandler
+
+import (
+	"fmt"
+
+	"golang.zx2c4.com/wireguard/wgctrl"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+)
+
+// WireGuard injects PSKs into a standard WireGuard interface via wgctrl (netlink).
+type WireGuard struct {
+	conn          *wgctrl.Client
+	interfaceName string
+	peerPublicKey string
+}
+
+func NewWireGuard(interfaceName, peerPublicKey string) (*WireGuard, error) {
+	client, err := wgctrl.New()
+	if err != nil {
+		return nil, err
+	}
+	return &WireGuard{
+		conn:          client,
+		interfaceName: interfaceName,
+		peerPublicKey: peerPublicKey,
+	}, nil
+}
+
+func (w *WireGuard) SetKey(psk string) error {
+	device, err := w.conn.Device(w.interfaceName)
+	if err != nil {
+		return fmt.Errorf("failed to get device %s: %w", w.interfaceName, err)
+	}
+	found := false
+	for _, peer := range device.Peers {
+		if peer.PublicKey.String() == w.peerPublicKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("peer with public key %s not found on interface %s", w.peerPublicKey, w.interfaceName)
+	}
+
+	pskKey, err := wgtypes.ParseKey(psk)
+	if err != nil {
+		return fmt.Errorf("failed to parse PSK: %w", err)
+	}
+	publicKey, err := wgtypes.ParseKey(w.peerPublicKey)
+	if err != nil {
+		return fmt.Errorf("failed to parse peer public key: %w", err)
+	}
+
+	return w.conn.ConfigureDevice(w.interfaceName, wgtypes.Config{
+		Peers: []wgtypes.PeerConfig{{
+			PublicKey:    publicKey,
+			UpdateOnly:   true,
+			PresharedKey: &pskKey,
+		}},
+	})
+}
+
+func (w *WireGuard) Invalidate() error {
+	psk, err := wgtypes.GenerateKey()
+	if err != nil {
+		return err
+	}
+	return w.SetKey(psk.String())
+}

--- a/keyhandler/wolfguard_linux.go
+++ b/keyhandler/wolfguard_linux.go
@@ -1,0 +1,182 @@
+//go:build linux
+
+package keyhandler
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/mdlayher/genetlink"
+	"github.com/mdlayher/netlink"
+	"github.com/mdlayher/netlink/nlenc"
+	"golang.org/x/sys/unix"
+)
+
+const wolfGuardGenlName = "wolfguard"
+
+// WolfGuard injects PSKs into a wolfGuard interface via generic netlink.
+// wolfGuard uses the same netlink attribute IDs as WireGuard but with a
+// different family name ("wolfguard") and larger ECC public keys (65-byte
+// uncompressed SECP256R1 instead of 32-byte Curve25519).
+type WolfGuard struct {
+	c             *genetlink.Conn
+	family        genetlink.Family
+	interfaceName string
+	peerPublicKey string // base64-encoded
+}
+
+func NewWolfGuard(interfaceName, peerPublicKey string) (*WolfGuard, error) {
+	c, err := genetlink.Dial(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open genetlink: %w", err)
+	}
+
+	f, err := c.GetFamily(wolfGuardGenlName)
+	if err != nil {
+		_ = c.Close()
+		return nil, fmt.Errorf("wolfguard netlink family not found (is the kernel module loaded?): %w", err)
+	}
+
+	return &WolfGuard{
+		c:             c,
+		family:        f,
+		interfaceName: interfaceName,
+		peerPublicKey: peerPublicKey,
+	}, nil
+}
+
+func (w *WolfGuard) SetKey(psk string) error {
+	peerPubKeyBytes, err := base64.StdEncoding.DecodeString(w.peerPublicKey)
+	if err != nil {
+		return fmt.Errorf("failed to decode peer public key: %w", err)
+	}
+
+	// Verify the peer exists on the interface.
+	peers, err := w.getPeerPublicKeys()
+	if err != nil {
+		return fmt.Errorf("failed to get device %s: %w", w.interfaceName, err)
+	}
+	found := false
+	for _, p := range peers {
+		if base64.StdEncoding.EncodeToString(p) == w.peerPublicKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("peer with public key %s not found on interface %s", w.peerPublicKey, w.interfaceName)
+	}
+
+	pskBytes, err := base64.StdEncoding.DecodeString(psk)
+	if err != nil {
+		return fmt.Errorf("failed to decode PSK: %w", err)
+	}
+	if len(pskBytes) != 32 {
+		return fmt.Errorf("PSK must be 32 bytes, got %d", len(pskBytes))
+	}
+
+	return w.configurePSK(peerPubKeyBytes, pskBytes)
+}
+
+func (w *WolfGuard) Invalidate() error {
+	var psk [32]byte
+	if _, err := rand.Read(psk[:]); err != nil {
+		return fmt.Errorf("failed to generate random PSK: %w", err)
+	}
+	return w.SetKey(base64.StdEncoding.EncodeToString(psk[:]))
+}
+
+// getPeerPublicKeys queries the wolfguard device and returns the raw public
+// key bytes for each configured peer.
+func (w *WolfGuard) getPeerPublicKeys() ([][]byte, error) {
+	b, err := netlink.MarshalAttributes([]netlink.Attribute{{
+		Type: unix.WGDEVICE_A_IFNAME,
+		Data: nlenc.Bytes(w.interfaceName),
+	}})
+	if err != nil {
+		return nil, err
+	}
+
+	msgs, err := w.execute(unix.WG_CMD_GET_DEVICE, netlink.Request|netlink.Dump, b)
+	if err != nil {
+		return nil, err
+	}
+
+	var keys [][]byte
+	for _, m := range msgs {
+		parsed, err := parseWolfGuardPeerKeys(m)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, parsed...)
+	}
+	return keys, nil
+}
+
+func parseWolfGuardPeerKeys(m genetlink.Message) ([][]byte, error) {
+	ad, err := netlink.NewAttributeDecoder(m.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	var keys [][]byte
+	for ad.Next() {
+		if ad.Type() != unix.WGDEVICE_A_PEERS {
+			continue
+		}
+		ad.Nested(func(nad *netlink.AttributeDecoder) error {
+			for nad.Next() {
+				nad.Nested(func(nnad *netlink.AttributeDecoder) error {
+					for nnad.Next() {
+						if nnad.Type() == unix.WGPEER_A_PUBLIC_KEY {
+							key := make([]byte, len(nnad.Bytes()))
+							copy(key, nnad.Bytes())
+							keys = append(keys, key)
+						}
+					}
+					return nil
+				})
+			}
+			return nil
+		})
+	}
+
+	if err := ad.Err(); err != nil {
+		return nil, err
+	}
+	return keys, nil
+}
+
+func (w *WolfGuard) configurePSK(peerPubKey, psk []byte) error {
+	ae := netlink.NewAttributeEncoder()
+	ae.String(unix.WGDEVICE_A_IFNAME, w.interfaceName)
+	ae.Nested(unix.WGDEVICE_A_PEERS, func(nae *netlink.AttributeEncoder) error {
+		nae.Nested(0, func(pae *netlink.AttributeEncoder) error {
+			pae.Bytes(unix.WGPEER_A_PUBLIC_KEY, peerPubKey)
+			pae.Uint32(unix.WGPEER_A_FLAGS, unix.WGPEER_F_UPDATE_ONLY)
+			pae.Bytes(unix.WGPEER_A_PRESHARED_KEY, psk)
+			return nil
+		})
+		return nil
+	})
+
+	attrs, err := ae.Encode()
+	if err != nil {
+		return err
+	}
+
+	_, err = w.execute(unix.WG_CMD_SET_DEVICE, netlink.Request|netlink.Acknowledge, attrs)
+	return err
+}
+
+func (w *WolfGuard) execute(command uint8, flags netlink.HeaderFlags, attrb []byte) ([]genetlink.Message, error) {
+	msg := genetlink.Message{
+		Header: genetlink.Header{
+			Command: command,
+			Version: 1,
+		},
+		Data: attrb,
+	}
+	return w.c.Execute(msg, w.family.ID, flags)
+}

--- a/keyhandler/wolfguard_stub.go
+++ b/keyhandler/wolfguard_stub.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package keyhandler
+
+import "fmt"
+
+func NewWolfGuard(interfaceName, peerPublicKey string) (*WolfGuard, error) {
+	return nil, fmt.Errorf("wolfguard is only supported on Linux")
+}
+
+// WolfGuard is a stub for non-Linux platforms.
+type WolfGuard struct{}
+
+func (w *WolfGuard) SetKey(psk string) error { return fmt.Errorf("wolfguard: not supported") }
+func (w *WolfGuard) Invalidate() error       { return fmt.Errorf("wolfguard: not supported") }

--- a/main.go
+++ b/main.go
@@ -229,6 +229,8 @@ func main() {
 	switch cfg.KeyHandler {
 	case "wireguard":
 		handler, err = keyhandler.NewWireGuard(cfg.WireGuardInterface, cfg.WireguardPeerPublicKey)
+	case "wolfguard":
+		handler, err = keyhandler.NewWolfGuard(cfg.WireGuardInterface, cfg.WireguardPeerPublicKey)
 	case "file":
 		handler, err = keyhandler.NewFile(cfg.KeyOutputFile)
 	default:

--- a/main.go
+++ b/main.go
@@ -225,9 +225,17 @@ func main() {
 	result := make(chan string)
 	kmsAuth := kms.NewClientCertificateAuth(cfg.Certificate, cfg.PrivateKey, cfg.CACertificate)
 	kmsServer := kms.NewKMSServer(cfg.KMSURL, cfg.KMSHTTPTimeout, cfg.KMSBackoffMaxRetries, cfg.KMSBackoffBaseDelay, kmsAuth)
-	handler, err := keyhandler.NewWireGuard(cfg.WireGuardInterface, cfg.WireguardPeerPublicKey)
+	var handler keyhandler.Handler
+	switch cfg.KeyHandler {
+	case "wireguard":
+		handler, err = keyhandler.NewWireGuard(cfg.WireGuardInterface, cfg.WireguardPeerPublicKey)
+	case "file":
+		handler, err = keyhandler.NewFile(cfg.KeyOutputFile)
+	default:
+		log.Panicf("[ERROR] [STOP] Unknown key handler: %s", cfg.KeyHandler)
+	}
 	if err != nil {
-		log.Panicf("[ERROR] [STOP] Failed to create key handler: %v", err)
+		log.Panicf("[ERROR] [STOP] Failed to create key handler (%s): %v", cfg.KeyHandler, err)
 	}
 	go tcpServer(cfg.ListenAddress, result, done)
 	go func() {

--- a/main.go
+++ b/main.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/arnika-project/arnika/config"
 	"github.com/arnika-project/arnika/kdf"
+	"github.com/arnika-project/arnika/keyhandler"
 	"github.com/arnika-project/arnika/kms"
-	wg "github.com/arnika-project/arnika/wireguard"
 )
 
 var (
@@ -137,15 +137,15 @@ func getPQCKey(pqcKeyFile string) (string, error) {
 	return scanner.Text(), nil
 }
 
-func setPSK(wireguard *wg.WireGuardHandler, qkd string, cfg *config.Config, logPrefix string) {
+func setPSK(handler keyhandler.Handler, qkd string, cfg *config.Config, logPrefix string) {
 	psk := qkd
 	msg := ""
 	defer func() {
 		if msg != "" {
 			log.Println(msg)
-			log.Printf("[ERROR] %s [STOP] configure random PSK to invalidate WireGuard session", logPrefix)
-			if err := wireguard.SetRandomPSK(cfg.WireGuardInterface, cfg.WireguardPeerPublicKey); err != nil {
-				log.Printf("[ERROR] %s failed to configure random PSK: %v", logPrefix, err)
+			log.Printf("[ERROR] %s [STOP] configure random key to invalidate session", logPrefix)
+			if err := handler.Invalidate(); err != nil {
+				log.Printf("[ERROR] %s failed to invalidate key: %v", logPrefix, err)
 			}
 		}
 	}()
@@ -188,11 +188,11 @@ func setPSK(wireguard *wg.WireGuardHandler, qkd string, cfg *config.Config, logP
 		msg = fmt.Sprintf("[ERROR] %s no PSK available", logPrefix)
 		return
 	}
-	if err := wireguard.SetKey(cfg.WireGuardInterface, cfg.WireguardPeerPublicKey, psk); err != nil {
-		msg = fmt.Sprintf("[ERROR] %s failed to configure PSK on WireGuard interface: %v", logPrefix, err)
+	if err := handler.SetKey(psk); err != nil {
+		msg = fmt.Sprintf("[ERROR] %s failed to deliver PSK: %v", logPrefix, err)
 		return
 	}
-	log.Printf("[INFO] %s [OK] PSK configured on WireGuard interface: %s for peer: %s", logPrefix, cfg.WireGuardInterface, cfg.WireguardPeerPublicKey)
+	log.Printf("[INFO] %s [OK] PSK delivered via key handler", logPrefix)
 }
 
 func main() {
@@ -225,9 +225,9 @@ func main() {
 	result := make(chan string)
 	kmsAuth := kms.NewClientCertificateAuth(cfg.Certificate, cfg.PrivateKey, cfg.CACertificate)
 	kmsServer := kms.NewKMSServer(cfg.KMSURL, cfg.KMSHTTPTimeout, cfg.KMSBackoffMaxRetries, cfg.KMSBackoffBaseDelay, kmsAuth)
-	wireguard, err := wg.NewWireGuardHandler()
+	handler, err := keyhandler.NewWireGuard(cfg.WireGuardInterface, cfg.WireguardPeerPublicKey)
 	if err != nil {
-		log.Panicf("[ERROR] [STOP] Failed to create WireGuard handler: %v", err)
+		log.Panicf("[ERROR] [STOP] Failed to create key handler: %v", err)
 	}
 	go tcpServer(cfg.ListenAddress, result, done)
 	go func() {
@@ -243,7 +243,7 @@ func main() {
 				log.Printf("[ERROR] %s failed to retrieve QKD key for key_id %s from %s, %v", BACKUPPREFIX, r, cfg.KMSURL, err)
 				continue
 			}
-			setPSK(wireguard, key.GetKey(), cfg, BACKUPPREFIX)
+			setPSK(handler, key.GetKey(), cfg, BACKUPPREFIX)
 		}
 	}()
 	go func() {
@@ -276,7 +276,7 @@ func main() {
 					if err != nil {
 						log.Printf("[ERROR] %s failed to send key_id %s to %s: %v", MASTERPREFIX, key.GetID(), cfg.ServerAddress, err)
 					}
-					setPSK(wireguard, key.GetKey(), cfg, MASTERPREFIX)
+					setPSK(handler, key.GetKey(), cfg, MASTERPREFIX)
 				}
 			}
 			<-ticker.C

--- a/main.go
+++ b/main.go
@@ -174,7 +174,6 @@ func setPSK(handler keyhandler.Handler, qkd string, cfg *config.Config, logPrefi
 					log.Printf("[WARNING] %s failed to decode PQC key, switching to QKD key since mode is set to %s", logPrefix, cfg.Mode)
 				}
 			} else {
-				// a key derivation will happen, either with key or with all zeros
 				psk, err = kdf.DeriveKey(psk, pqc)
 				if err != nil {
 					msg = fmt.Sprintf("[ERROR] %s failed to derive key: %v. Abort since mode is set to %s", logPrefix, err, cfg.Mode)
@@ -192,7 +191,7 @@ func setPSK(handler keyhandler.Handler, qkd string, cfg *config.Config, logPrefi
 		msg = fmt.Sprintf("[ERROR] %s failed to deliver PSK: %v", logPrefix, err)
 		return
 	}
-	log.Printf("[INFO] %s [OK] PSK delivered via key handler", logPrefix)
+	log.Printf("[INFO] %s [OK] PSK delivered via %s handler", logPrefix, cfg.KeyHandler)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -230,6 +230,8 @@ func main() {
 		handler, err = keyhandler.NewWireGuard(cfg.WireGuardInterface, cfg.WireguardPeerPublicKey)
 	case "wolfguard":
 		handler, err = keyhandler.NewWolfGuard(cfg.WireGuardInterface, cfg.WireguardPeerPublicKey)
+	case "macsec":
+		handler, err = keyhandler.NewMACsec(cfg.MACsecInterface, cfg.MACsecRxSCI)
 	case "file":
 		handler, err = keyhandler.NewFile(cfg.KeyOutputFile)
 	default:


### PR DESCRIPTION
This PR adds support for WolfGuard, which was announced the other week. I'm not sure who will use it, but due to its similarity with WireGuard, support is somewhat simple. 

While at it, let's add a file output options. This allows to store the retrieved QKD keys in a file, to be used by other tools.